### PR TITLE
Sort VPN names

### DIFF
--- a/vpnlist.sh
+++ b/vpnlist.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 get_vpn_names() {
-  scutil --nc list | grep "com.wireguard.macos" | awk -F'"' '{print$2}'
+  scutil --nc list | grep "com.wireguard.macos" | awk -F'"' '{print$2}' | sort
 }
 
 get_vpn_status() {


### PR DESCRIPTION
This change sorts the VPN names the same way that the macOS client does and prevents items from moving around.